### PR TITLE
Fix Psych parse error

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,8 +1,8 @@
 en:
   crudify:
-    created: %{what} was successfully created.
-    updated: %{what} was successfully updated.
-    destroyed: %{what} was successfully removed. 
-    failed_create: %{what} could not be created. 
-    failed_update: %{what} could not be updated. 
-    failed_destroy: %{what} could not be removed. 
+    created: "%{what} was successfully created."
+    updated: "%{what} was successfully updated."
+    destroyed: "%{what} was successfully removed."
+    failed_create: "%{what} could not be created."
+    failed_update: "%{what} could not be updated."
+    failed_destroy: "%{what} could not be removed."


### PR DESCRIPTION
## Problem

Psych raises a SyntaxError for config/locales/en.yml unless elements are explicitly wrapped in double quotes.

For example, on master:

```
$ irb
ruby-1.9.2-p290 :001 > require 'yaml'
 => true 
ruby-1.9.2-p290 :002 > require 'psych'
 => true 
ruby-1.9.2-p290 :003 > YAML::ENGINE.yamler = 'syck'
 => "syck" 
ruby-1.9.2-p290 :005 > YAML.load(File.read("config/locales/en.yml"))
 => {"en"=>{"crudify"=>{"created"=>"%{what} was successfully created.", "updated"=>"%{what} was successfully updated.", "destroyed"=>"%{what} was successfully removed.", "failed_create"=>"%{what} could not be created.", "failed_update"=>"%{what} could not be updated.", "failed_destroy"=>"%{what} could not be removed."}}} 
ruby-1.9.2-p290 :006 > YAML::ENGINE.yamler = 'psych'
 => "psych" 
ruby-1.9.2-p290 :007 > YAML.load(File.read("config/locales/en.yml"))
Psych::SyntaxError: couldn't parse YAML at line 3 column 13
    from /home/ben/.rvm/rubies/ruby-1.9.2-p290/lib/ruby/1.9.1/psych.rb:148:in `parse'
    from /home/ben/.rvm/rubies/ruby-1.9.2-p290/lib/ruby/1.9.1/psych.rb:148:in `parse_stream'
    from /home/ben/.rvm/rubies/ruby-1.9.2-p290/lib/ruby/1.9.1/psych.rb:119:in `parse'
    from /home/ben/.rvm/rubies/ruby-1.9.2-p290/lib/ruby/1.9.1/psych.rb:106:in `load'
    from (irb):7
    from /home/ben/.rvm/rubies/ruby-1.9.2-p290/bin/irb:16:in `<main>'
```

On branch fix_psych_parse_error:

```
$ irb
ruby-1.9.2-p290 :001 > require 'yaml'
 => true 
ruby-1.9.2-p290 :002 > require 'psych'
 => true 
ruby-1.9.2-p290 :003 > YAML::ENGINE.yamler = 'syck'
 => "syck" 
ruby-1.9.2-p290 :004 > YAML.load(File.read("config/locales/en.yml"))
 => {"en"=>{"crudify"=>{"created"=>"%{what} was successfully created.", "updated"=>"%{what} was successfully updated.", "destroyed"=>"%{what} was successfully removed.", "failed_create"=>"%{what} could not be created.", "failed_update"=>"%{what} could not be updated.", "failed_destroy"=>"%{what} could not be removed."}}} 
ruby-1.9.2-p290 :005 > YAML::ENGINE.yamler = 'psych'
 => "psych" 
ruby-1.9.2-p290 :006 > YAML.load(File.read("config/locales/en.yml"))
 => {"en"=>{"crudify"=>{"created"=>"%{what} was successfully created.", "updated"=>"%{what} was successfully updated.", "destroyed"=>"%{what} was successfully removed.", "failed_create"=>"%{what} could not be created.", "failed_update"=>"%{what} could not be updated.", "failed_destroy"=>"%{what} could not be removed."}}} 
```
